### PR TITLE
fix: make process management cross-platform (windows support)

### DIFF
--- a/internal/runner/server_runner.go
+++ b/internal/runner/server_runner.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/chibuka/95-cli/client"
@@ -39,7 +38,7 @@ func (h *httpServerRunner) startServer(programConfig *client.ProgramConfig, runC
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	h.cmd.Env = env
-	h.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	h.cmd.SysProcAttr = sysProcAttr()
 
 	// Capture output for debugging
 	var stdout, stderr bytes.Buffer
@@ -110,6 +109,6 @@ func (h *httpServerRunner) stopServer() {
 		// Process exited
 	case <-time.After(2 * time.Second):
 		// Force kill
-		syscall.Kill(-h.cmd.Process.Pid, syscall.SIGKILL)
+		killProcess(-h.cmd.Process.Pid)
 	}
 }

--- a/internal/runner/server_runner_unix.go
+++ b/internal/runner/server_runner_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package runner
+
+import "syscall"
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+func killProcess(pid int) error {
+	return syscall.Kill(-pid, syscall.SIGTERM)
+}

--- a/internal/runner/server_runner_windows.go
+++ b/internal/runner/server_runner_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package runner
+
+import (
+	"os"
+	"syscall"
+)
+
+func sysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}
+
+func killProcess(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}


### PR DESCRIPTION
- split unix/windows process logic using build tags
- remove unix-only syscalls (Setpgid, syscall.Kill) from windows builds
- use os.Process for process termination on windows